### PR TITLE
Exposed host in JS WebPack config

### DIFF
--- a/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/targets/js/webpack/KotlinWebpackConfig.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/targets/js/webpack/KotlinWebpackConfig.kt
@@ -94,6 +94,7 @@ data class KotlinWebpackConfig(
         val open: Any = true,
         val overlay: Any = false,
         val port: Int = 8080,
+        val host: String = "localhost",
         val proxy: Map<String, Any>? = null,
         val contentBase: List<String>
     ) : Serializable


### PR DESCRIPTION
By allowing "host" to be specified for the DevServer of a WebPack config, it can be set to "0.0.0.0" to allow access from other computers on the network. See, for example, the discussion here: https://github.com/webpack/webpack-dev-server/issues/147.

Another solution could be to expose the arguments created in KotlinWebpackRunner.kt. However, such a solution would be more invasive.